### PR TITLE
add bin field to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "description": "Takes files from a src and creates a language dir and translate file based on multiple files parts",
   "license": "GPLv2",
   "author": "HomeOffice",
+  "contributors": [
+    "Ben Marvell <github@marvell-consulting.com> (http://www.marvell-consulting.com/)",
+    "Joseph Chapman <joe@creatify-limited.com> (http://www.creatify-limited.com/)"
+  ],
+  "bin": "./bin/hof-transpiler",
   "dependencies": {
     "mkdirp": "^0.5.1",
     "rimraf": "^2.4.3",


### PR DESCRIPTION
On install, npm will symlink the file into prefix/bin for global installs, or ./node_modules/.bin/ for local installs.
