### PR TITLE
hof-transpile now combines duplicate files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/*
+node_modules/*

--- a/bin/hof-transpiler
+++ b/bin/hof-transpiler
@@ -5,6 +5,8 @@ var fs = require('fs');
 var walk = require('walk');
 var path = require('path');
 var _ = require('underscore');
+var underscoreDeepExtend = require('underscore-deep-extend');
+_.mixin({deepExtend: underscoreDeepExtend(_)});
 var rimraf = require('rimraf');
 var argv = require('minimist')(process.argv.slice(2));
 var sources = argv._;
@@ -93,7 +95,7 @@ _.each(sources, function (src) {
         sharedMap[lang][fileName] = parseFileSync(path.resolve(root, fileStats.name));
 
         parsedStream = parseFileSync(writerStream.path);
-        _.extend(parsedStream, sharedMap[streamLang]);
+        _.deepExtend(parsedStream, sharedMap[streamLang]);
         stringStream = JSON.stringify(parsedStream, null, '\t');
 
         fs.writeFileSync(writerStream.path, stringStream, 'utf8');

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "mkdirp": "^0.5.1",
     "rimraf": "^2.4.3",
     "underscore": "^1.8.3",
+    "underscore-deep-extend": "0.0.5",
     "walk": "^2.3.9"
   }
 }


### PR DESCRIPTION
Previously if there was a duplicate file in shared and the usual path
the shared file would take precedence.
Now the 2 files will be merged, keeping the contents of both
