### PR TITLE
Bugfix/shared should not overwrite

### DIFF
--- a/bin/hof-transpiler
+++ b/bin/hof-transpiler
@@ -94,8 +94,8 @@ _.each(sources, function (src) {
         sharedMap[lang] = sharedMap[lang] || {};
         sharedMap[lang][fileName] = parseFileSync(path.resolve(root, fileStats.name));
 
-        parsedStream = parseFileSync(writerStream.path);
-        _.deepExtend(parsedStream, sharedMap[streamLang]);
+        parsedStream = sharedMap[streamLang];
+        _.deepExtend(parsedStream, parseFileSync(writerStream.path));
         stringStream = JSON.stringify(parsedStream, null, '\t');
 
         fs.writeFileSync(writerStream.path, stringStream, 'utf8');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-transpiler",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "./bin/hof-transpiler",
   "description": "Takes files from a src and creates a language dir and translate file based on multiple files parts",
   "license": "GPLv2",


### PR DESCRIPTION
This fixes a bug in hof-transpile where it prefers the "shared" definitions over the specific ones.

Code review appreciated to ascertain whether this is the correct way to fix this!
