### PR TITLE
Create a key for the currently streamed language

### DIFF
--- a/bin/hof-transpiler
+++ b/bin/hof-transpiler
@@ -100,6 +100,7 @@ _.each(sources, function (src) {
           var stringStream = '';
 
           sharedMap[lang] = sharedMap[lang] || {};
+          sharedMap[streamLang] = sharedMap[streamLang] || {};
           sharedMap[lang][fileName] = parseFileSync(path.resolve(root, fileStats.name));
 
           parsedStream = sharedMap[streamLang];


### PR DESCRIPTION
Fixes an issue when translating inside `common` in which `parsedStream` was returning `undefined`, as no key yet existed for it.
- Mirrors same behaviour has expressed for `sharedMap[lang]`, just ensures we set a key on `streamLang` as well
