### PR TITLE
Make parse-args its own module, add tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
 node_modules
-test

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,2 @@
 node_modules
-acceptance_tests
-public
-apps/**/translations/**/default.json
 test

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+acceptance_tests
+public
+apps/**/translations/**/default.json
+test

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,31 @@
+# 0 - disable
+#     Rules that more harmful than useful, or just buggy.
+#
+# 1 - warning
+#     Rules that we didn't encounter yet.
+#     You can safely ignore them, but I'd like to know
+#     any interesting use-cases they forbid.
+#
+# 2 - error
+#     Rules that have proven to be useful, please follow them.
+#
+
+env:
+  es6: true
+  node: true
+rules:
+  # important ones
+  no-undef: 2
+  no-underscore-dangle: 2
+  no-warning-comments: 2
+  no-redeclare: 2
+  no-unused-vars: [2, 'local']
+  quotes: [2, 'single', {'allowTemplateLiterals': true}]
+  # less important ones
+  new-cap: 1 # new Foo()
+  no-bitwise: 1 # no x &= y; for you
+  no-debugger: 1
+  no-console: 1
+  # no-reserved-keys: 2 # disallow reserved words being used as object literal keys (off by default)
+plugins:
+  - mocha

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,22 +10,16 @@
 #     Rules that have proven to be useful, please follow them.
 #
 
+extends:
+- "homeoffice/config/default"
+
 env:
   es6: true
   node: true
 rules:
-  # important ones
-  no-undef: 2
-  no-underscore-dangle: 2
-  no-warning-comments: 2
-  no-redeclare: 2
-  no-unused-vars: [2, 'local']
-  quotes: [2, 'single', {'allowTemplateLiterals': true}]
-  # less important ones
-  new-cap: 1 # new Foo()
-  no-bitwise: 1 # no x &= y; for you
-  no-debugger: 1
+  ## overides of homeoffice/config/default
+  space-before-function-paren: 0 # i <3 spaces before function parens
   no-console: 1
-  # no-reserved-keys: 2 # disallow reserved words being used as object literal keys (off by default)
+  consistent-return: off
 plugins:
   - mocha

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/*
-node_modules/*
+node_modules
+.DS_Store

--- a/bin/hof-transpiler
+++ b/bin/hof-transpiler
@@ -15,24 +15,25 @@ var underscoreDeepExtend = require('underscore-deep-extend');
 _.mixin({deepExtend: underscoreDeepExtend(_)});
 var rimraf = require('rimraf');
 
-function parseFileSync(path) {
+function parseFileSync(filePath) {
   try {
-    return JSON.parse(fs.readFileSync(path, 'utf8'));
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
   } catch (error) {
     throw new Error(error);
   }
 }
 
-function getLanguage(path) {
-  var parts = path.split('/');
+function getLanguage(langPath) {
+  var parts = langPath.split('/');
   return parts[parts.length - 1];
 }
 
-_.each(sources, function (src) {
+_.each(sources, function walking (src) {
   var walker = walk.walk(src);
   var writeFileStream = {};
   var firstFileForDir = {};
 
+  /* eslint func-names:0 max-nested-callbacks:0 */
   walker.on('directory', function (root, dirStats, next) {
     var languagePath = path.resolve(root.replace('/src', ''), dirStats.name);
 
@@ -41,11 +42,17 @@ _.each(sources, function (src) {
         throw Error(err);
       }
 
-      mkdirp(languagePath, function (err) {
-        if (err) {
-          throw Error(err);
+      mkdirp(languagePath, function (mkerr) {
+        if (mkerr) {
+          throw Error(mkerr);
         }
-        writeFileStream[dirStats.name] = require('fs').createWriteStream(path.resolve(root.replace('/src', ''), dirStats.name, 'default.json'));
+        writeFileStream[dirStats.name] = require('fs')
+          .createWriteStream(
+            path.resolve(root.replace('/src', ''),
+              dirStats.name,
+              'default.json'
+            )
+          );
         writeFileStream[dirStats.name].write('{');
         next();
       });

--- a/bin/hof-transpiler
+++ b/bin/hof-transpiler
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 
-var mkdirp = require("mkdirp");
+'use strict';
+
+const parsed = require('../lib/parse-args')(process.argv.slice(2));
+let sources = parsed.sources;
+let shared = parsed.shared;
+
+var mkdirp = require('mkdirp');
 var fs = require('fs');
 var walk = require('walk');
 var path = require('path');
@@ -8,26 +14,6 @@ var _ = require('underscore');
 var underscoreDeepExtend = require('underscore-deep-extend');
 _.mixin({deepExtend: underscoreDeepExtend(_)});
 var rimraf = require('rimraf');
-var argv = require('minimist')(process.argv.slice(2));
-var sources = argv._;
-var shared = argv.s || argv.shared;
-var writeShared = argv.writeShared || argv.w;
-
-if (!Array.isArray(shared)) {
-  shared = [shared];
-}
-
-shared.reverse();
-
-if (!sources.length) {
-  throw new Error('No src specified');
-}
-
-if (writeShared !== true) {
-  sources = sources.filter(function (source) {
-    return shared.indexOf(source) === -1
-  });
-}
 
 function parseFileSync(path) {
   try {
@@ -43,7 +29,6 @@ function getLanguage(path) {
 }
 
 _.each(sources, function (src) {
-  var contents = '';
   var walker = walk.walk(src);
   var writeFileStream = {};
   var firstFileForDir = {};

--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -16,11 +16,13 @@ const parse = (args) => {
     shared = [shared];
   }
 
-  shared && shared.reverse();
+  if (shared) {
+    shared.reverse();
+  }
 
   if (shared && writeShared !== true) {
     sources = sources.filter((source) => {
-      return shared.indexOf(source) === -1
+      return shared.indexOf(source) === -1;
     });
   }
 
@@ -28,6 +30,6 @@ const parse = (args) => {
     sources: sources,
     shared: shared
   };
-}
+};
 
 module.exports = parse;

--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const minimist = require('minimist');
+
+const parse = (args) => {
+  if (!args || args.length === 0) {
+    throw new Error('No src folder or pattern specified');
+  }
+  const parsed = minimist(args);
+  const writeShared = parsed.writeShared || parsed.w;
+
+  let sources = parsed._;
+  let shared = parsed.s || parsed.shared;
+
+  if (shared && !Array.isArray(shared)) {
+    shared = [shared];
+  }
+
+  shared && shared.reverse();
+
+  if (shared && writeShared !== true) {
+    sources = sources.filter((source) => {
+      return shared.indexOf(source) === -1
+    });
+  }
+
+  return {
+    sources: sources,
+    shared: shared
+  };
+}
+
+module.exports = parse;

--- a/package.json
+++ b/package.json
@@ -17,5 +17,12 @@
     "underscore": "^1.8.3",
     "underscore-deep-extend": "0.0.5",
     "walk": "^2.3.9"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "eslint-plugin-mocha": "^4.5.1",
+    "mocha": "^3.0.2",
+    "proxyquire": "^1.7.10",
+    "sinon": "^1.17.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "eslint-config-homeoffice": "^1.0.0",
     "eslint-plugin-mocha": "^4.5.1",
     "mocha": "^3.0.2",
     "proxyquire": "^1.7.10",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
     "chai": "^3.5.0",
     "eslint-config-homeoffice": "^1.0.0",
     "eslint-plugin-mocha": "^4.5.1",
-    "mocha": "^3.0.2",
-    "proxyquire": "^1.7.10",
-    "sinon": "^1.17.5"
+    "mocha": "^3.0.2"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -6,10 +6,7 @@ env:
   mocha: true
 globals:
   chai: true
-  expect: true
-  sinon: true
   should: true
-  proxyquire: true
 rules:
   func-names: 0
   max-nested-callbacks: 0

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,3 +1,7 @@
+extends:
+  - '../.eslintrc'
+  - 'homeoffice/config/testing'
+
 env:
   mocha: true
 globals:

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,14 @@
+env:
+  mocha: true
+globals:
+  chai: true
+  expect: true
+  sinon: true
+  should: true
+  proxyquire: true
+rules:
+  func-names: 0
+  max-nested-callbacks: 0
+  no-unused-expressions: 0
+  no-process-env: 0
+  no-console: 0

--- a/test/globals.js
+++ b/test/globals.js
@@ -1,0 +1,6 @@
+'use strict';
+
+global.chai = require('chai')
+global.should = global.chai.should()
+global.sinon = require('sinon')
+global.proxyquire = require('proxyquire')

--- a/test/globals.js
+++ b/test/globals.js
@@ -1,4 +1,4 @@
 'use strict';
 
-global.chai = require('chai')
-global.should = global.chai.should()
+global.chai = require('chai');
+global.should = global.chai.should();

--- a/test/globals.js
+++ b/test/globals.js
@@ -2,5 +2,3 @@
 
 global.chai = require('chai')
 global.should = global.chai.should()
-global.sinon = require('sinon')
-global.proxyquire = require('proxyquire')

--- a/test/lib/parse-args.spec.js
+++ b/test/lib/parse-args.spec.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const parse = require('../../lib/parse-args');
+
+describe('parse-args', () => {
+  describe('no args!', () => {
+    [[],Number(),'',null,undefined].forEach((type) => {
+      it(`${typeof type} '${type}' should throw`, () => {
+        (() => {
+          parse(type)
+        }).should.throw('No src folder or pattern specified');
+      });
+    })
+  });
+
+  describe('args!', () => {
+    describe('just sources', () => {
+      let result = parse(['foo/**/bar']);
+
+      it('returns sources', () => result.sources.should
+        .deep.equal([ 'foo/**/bar' ]))
+
+      it('shared is undefined', () => {
+        should.not.exist(result.shared);
+      });
+
+      it('throws with array')
+
+    });
+
+    describe('sources and shared', () => {
+      let src = 'foo/**/bar';
+      describe('without --writeShared', () => {
+        let result = parse([
+          src,
+          '-s', 'common/**/foo',
+          '-s', 'common/**/bar'
+        ]);
+
+        it('returns sources', () => result.sources.should
+          .deep.equal([ 'foo/**/bar' ]))
+
+        it('shared is an array', () => {
+          result.shared.should.be.an('Array');
+        });
+
+        it('shared is parsed, reversed', () => {
+          result.shared.should.deep.equal([
+            'common/**/bar',
+            'common/**/foo'
+          ])
+        });
+      });
+      describe('with --writeShared', () => {
+
+        it('makes no actual difference to entire thing')
+
+        let result = parse([
+          'app/**/translations',
+          '-w',
+          '-s', 'common/**/foo',
+          '-s', 'common/**/bar'
+        ]);
+
+        it('returns sources', () => result.sources.should
+          .deep.equal([ 'app/**/translations' ]))
+
+        it('shared is an array', () => {
+          result.shared.should.be.an('Array');
+        });
+
+        it('shared is parsed', () => {
+          result.shared.should.deep.equal([
+            'common/**/bar',
+            'common/**/foo'
+            ])
+        });
+
+      });
+    });
+  });
+});

--- a/test/lib/parse-args.spec.js
+++ b/test/lib/parse-args.spec.js
@@ -4,13 +4,13 @@ const parse = require('../../lib/parse-args');
 
 describe('parse-args', () => {
   describe('no args!', () => {
-    [[],Number(),'',null,undefined].forEach((type) => {
+    [[], Number(), '', null, undefined].forEach((type) => {
       it(`${typeof type} '${type}' should throw`, () => {
         (() => {
-          parse(type)
+          parse(type);
         }).should.throw('No src folder or pattern specified');
       });
-    })
+    });
   });
 
   describe('args!', () => {
@@ -18,13 +18,13 @@ describe('parse-args', () => {
       let result = parse(['foo/**/bar']);
 
       it('returns sources', () => result.sources.should
-        .deep.equal([ 'foo/**/bar' ]))
+        .deep.equal(['foo/**/bar']));
 
       it('shared is undefined', () => {
         should.not.exist(result.shared);
       });
 
-      it('throws with array')
+      it('throws with array');
 
     });
 
@@ -38,7 +38,7 @@ describe('parse-args', () => {
         ]);
 
         it('returns sources', () => result.sources.should
-          .deep.equal([ 'foo/**/bar' ]))
+          .deep.equal(['foo/**/bar']));
 
         it('shared is an array', () => {
           result.shared.should.be.an('Array');
@@ -48,12 +48,12 @@ describe('parse-args', () => {
           result.shared.should.deep.equal([
             'common/**/bar',
             'common/**/foo'
-          ])
+          ]);
         });
       });
       describe('with --writeShared', () => {
 
-        it('makes no actual difference to entire thing')
+        it('makes no actual difference to entire thing');
 
         let result = parse([
           'app/**/translations',
@@ -63,7 +63,7 @@ describe('parse-args', () => {
         ]);
 
         it('returns sources', () => result.sources.should
-          .deep.equal([ 'app/**/translations' ]))
+          .deep.equal(['app/**/translations']));
 
         it('shared is an array', () => {
           result.shared.should.be.an('Array');
@@ -73,7 +73,7 @@ describe('parse-args', () => {
           result.shared.should.deep.equal([
             'common/**/bar',
             'common/**/foo'
-            ])
+            ]);
         });
 
       });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--require test/globals.js
+--recursive
+--reporter spec


### PR DESCRIPTION
### behold, the beginning of tests

![screen shot 2016-09-15 at 10 32 43](https://cloud.githubusercontent.com/assets/120181/18545173/dcc741fa-7b2f-11e6-8d02-e09c32304ea9.png)
- tests arguments are passed in as we expect
- raises question about the importance of the `-w` flag
- use unit tested args parser inside hof-transpiler
### Adds homeoffice eslint config, does some linting ✂️  …
- keeping spaces before function parens but most everything else is maintained
- have cheated on the walker nesting errors, because that is work to do later

fixes #19 
begins #16 
