### PR TITLE
Fix race conditions and object mutation

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 const path = require('path');
 const mkdirp = require('mkdirp');
 const walk = require('walk');
+const async = require('async');
+const merge = require('lodash.merge');
 const getLanguage = (langPath) => langPath.split('/').pop();
 
 const parseFileSync = (filePath) => {
@@ -34,9 +36,10 @@ const directory = (root, dirStats, next, translationObject) => {
 };
 
 const compile = (args, cb) => {
+  cb = cb || function () {};
   let sources = args.sources;
   let shared = args.shared;
-  sources.forEach(function walking (src) {
+  async.eachSeries(sources, function walking (src, callback) {
     var walker = walk.walk(src);
     var writeFileStream = {};
     var firstFileForDir = {};
@@ -67,10 +70,11 @@ const compile = (args, cb) => {
     });
 
     walker.on('end', function () {
-      Object.keys(writeFileStream).forEach((key) => {
+      async.eachSeries(Object.keys(writeFileStream), (key, filecallback) => {
+        writeFileStream[key].end('}');
         var sharedMap = {};
 
-        shared.forEach(function (sharedSource) {
+        async.eachSeries(shared, function (sharedSource, sharedcallback) {
           walk.walk(sharedSource).on('file', function (root, fileStats, next) {
             var lang = getLanguage(root);
             var streamLang = getLanguage(path.parse(writeFileStream[key].path).dir);
@@ -84,22 +88,19 @@ const compile = (args, cb) => {
             sharedMap[lang][fileName] = parseFileSync(path.resolve(root, fileStats.name));
 
             current = sharedMap[streamLang];
-
-            combined = Object.assign(current, parseFileSync(writeFileStream[key].path));
+            combined = merge(current, parseFileSync(writeFileStream[key].path));
             strung = JSON.stringify(combined, null, '\t');
 
             fs.writeFileSync(writeFileStream[key].path, strung, 'utf8');
             next();
-          });
+          }).on('end', sharedcallback);
+        }, function (e) {
+          filecallback(e);
         });
 
-        writeFileStream[key].end('}');
-      });
-      if (cb) {
-        cb();
-      }
+      }, callback);
     });
-  });
+  }, cb);
 
 };
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test": "node_modules/.bin/mocha"
   },
   "dependencies": {
+    "async": "^2.1.4",
+    "lodash.merge": "^4.6.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.4.3",

--- a/test/fixtures/shared/src/en/errorlist.json
+++ b/test/fixtures/shared/src/en/errorlist.json
@@ -1,0 +1,5 @@
+{
+  "title": {
+    "triple": "Check your answers:"
+  }
+}

--- a/test/lib/compile.spec.js
+++ b/test/lib/compile.spec.js
@@ -92,6 +92,35 @@ describe('compile', () => {
           });
         });
       });
+
+      describe('with shared document', () => {
+        before('compile, then read compiled files', (done) => {
+          compile({
+            sources: [fixtures],
+            shared: ['./test/fixtures/shared/src']
+          }, () => {
+            // Allow time for files to be written, callback seems to be reliable
+            // for write, but doesn't account for stat/read speed
+            ensrc = path.resolve(fixtures.replace('src', 'en'));
+            arsrc = path.resolve(fixtures.replace('src', 'ar'));
+            enDir = fs.readdirSync(ensrc);
+            arDir = fs.readdirSync(arsrc);
+            english = fs.readFileSync(ensrc + '/default.json', 'utf8');
+            arabic = fs.readFileSync(arsrc + '/default.json', 'utf8');
+            done();
+          });
+        });
+
+        it('merges objects', () => {
+          JSON.parse(english).errorlist.title.should.have.keys([
+            'single',
+            'multiple',
+            'triple'
+          ]);
+        });
+
+      });
+
     });
   });
 });


### PR DESCRIPTION
Async file traversal and compilation inside synchronous loops meant that files were being written and read at the same time, casuing sporadic erros in compilation.

Furthermore, `Object.assign` was being used in place of a recursive merge function to combine files, which results in keys being overwritten inside nested objects.

For example: `Object.assign({ foo: { bar: 1 } }, { foo: { baz: 2 } }) === { foo: { baz: 2 } }` where instead `merge` called with the same arguments yields `{ foo: { bar:1, baz: 2 } }`, which is preferable in our case. This manifested as a bug in com[ilation where multiple shared sources were applied, resulting in the `fields` property of the last source to be applied removing any existing fields from the translation.