### PR TITLE
Remove redundant try/catch

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -9,11 +9,7 @@ const merge = require('lodash.merge');
 const getLanguage = (langPath) => langPath.split('/').pop();
 
 const parseFileSync = (filePath) => {
-  try {
-    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  } catch (error) {
-    throw new Error(error);
-  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 };
 
 const directory = (root, dirStats, next, translationObject) => {


### PR DESCRIPTION
Wrapping a statement in a try catch only to immediately throw if it fails is roughly a no-op, except in this case because the error was being passed as an argument into a new Error, it obfuscates the original error, making debugging unnecessarily difficult.

Remove the try/catch altogether and let the original error throw.