### PR TITLE
Fix broken option parsing

### DIFF
--- a/bin/hof-transpiler
+++ b/bin/hof-transpiler
@@ -8,8 +8,6 @@ const compile = require('../lib/compile');
 const options = {};
 
 options.sources = args._;
-
-options.shared = args.shared || [];
-options.shared = args.shared.concat(args.s || []);
+options.shared = args.shared || args.s || [];
 
 compile(options);


### PR DESCRIPTION
This threw an error if the binary was called without a `--shared` option because the code was wrong.