### PR TITLE
Check "languages" are actually directories before traversing

### DIFF
--- a/lib/aggregate.js
+++ b/lib/aggregate.js
@@ -15,14 +15,17 @@ module.exports = (dir, namespace) => {
   const langs = fs.readdirSync(dir);
 
   const resources = langs.reduce((map, lang) => {
-    map[lang] = { default: {} };
-    const files = fs.readdirSync(path.resolve(dir, lang));
-    files.forEach(file => {
-      if (path.extname(file) === '.json') {
-        const name = path.basename(file, '.json');
-        map[lang].default[name] = require(path.resolve(dir, lang, file));
-      }
-    });
+    const stat = fs.statSync(path.resolve(dir, lang));
+    if (stat.isDirectory()) {
+      map[lang] = { default: {} };
+      const files = fs.readdirSync(path.resolve(dir, lang));
+      files.forEach(file => {
+        if (path.extname(file) === '.json') {
+          const name = path.basename(file, '.json');
+          map[lang].default[name] = require(path.resolve(dir, lang, file));
+        }
+      });
+    }
     return map;
   }, {});
 


### PR DESCRIPTION
If the `./src` directory contains anything which is not a directory, a .DS_Store file for example, then the traversal fails because it attempts to traverse a non-directory.

Add a `stat` check before traversal to filter out non-directories.